### PR TITLE
Fix NPM and Bower module names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ Complete examples:
 ## Download / Install
 
 - Download [javascript file](https://raw.github.com/raimohanska/bacon.matchers/master/bacon.matchers.js)
-- NPM: registered as `bacon-matchers`
-- Bower: registered as `bacon-matchers`
+- NPM: registered as `bacon.matchers`
+- Bower: registered as `bacon.matchers`


### PR DESCRIPTION
Package names changed in README.md to correspond with component.json,
bower.json and NPM package repository. Also registered bacon.matchers as
a bower component because it was missing from bower repository.
